### PR TITLE
Use HTTP/2 for GRPC protocol (doesn't not support https)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,5 @@ WORKDIR '/app'
 COPY --from=library/docker:latest /usr/local/bin/docker /usr/bin/docker
 COPY --from=docker/compose:latest /usr/local/bin/docker-compose /usr/bin/docker-compose
 RUN apk add --no-cache tcpdump
+RUN apk add --no-cache curl
+RUN apk add --no-cache nghttp2

--- a/Http2Proxy.ts
+++ b/Http2Proxy.ts
@@ -1,0 +1,176 @@
+import url from 'url'
+import http2, { ClientHttp2Stream, Http2ServerRequest, Http2ServerResponse } from 'http2'
+import Global from './server/src/Global'
+import ProxyConfig from './common/ProxyConfig'
+import HttpMessage from './server/src/HttpMessage'
+import querystring from 'querystring'
+import HexFormatter from './server/src/formatters/HexFormatter'
+const decompressResponse = require('decompress-response')
+
+/**
+ * Important: This module must remain at the project root to properly set the document root for the index.html.
+ */
+export default class HttpProxy {
+  public constructor (proxyConfig: ProxyConfig) {
+    const server = http2.createServer() // HTTPS is not currently supported
+    proxyConfig._server = server
+
+    listen(server)
+
+    let retries = 0
+    let wait = 1000
+
+    server.on('error', (err) => {
+      if (++retries < 10) {
+        setTimeout(() => listen(server), wait *= 2)
+      } else {
+        console.error('Http2Proxy server error', err)
+      }
+    })
+
+    server.on('request', onRequest)
+
+    function listen (server: http2.Http2Server) {
+      server.listen(proxyConfig.port, () => {
+        console.log(`Listening on http2 port ${proxyConfig.port} for target host ${proxyConfig.hostname}`)
+      })
+    }
+
+    async function onRequest (clientReq: Http2ServerRequest, clientRes: Http2ServerResponse) {
+      const sequenceNumber = ++Global.nextSequenceNumber
+      const remoteAddress = clientReq.socket.remoteAddress
+      // eslint-disable-next-line node/no-deprecated-api
+      const reqUrl = url.parse(clientReq.url ? clientReq.url : '')
+
+      const httpMessage = new HttpMessage(
+        proxyConfig,
+        sequenceNumber,
+        remoteAddress!,
+        clientReq.method!,
+        clientReq.url!,
+        clientReq.headers
+      )
+
+      const requestBodyPromise = getReqBody(clientReq)
+
+      httpMessage.emitMessageToBrowser('') // No request body received yet
+      proxyRequest(proxyConfig!, requestBodyPromise)
+
+      function proxyRequest (proxyConfig: ProxyConfig, requestBodyPromise: Promise<string | {}>) {
+        clientReq.on('close', function () {
+          // sendErrorResponse(499, "Client closed connection", undefined, proxyConfig.path);
+        })
+
+        clientReq.on('error', function (error) {
+          console.error(sequenceNumber, 'Client connection error', JSON.stringify(error, null, 2))
+        })
+
+        const headers = clientReq.headers
+        headers.host = proxyConfig.hostname
+        if (proxyConfig.port) headers.host += ':' + proxyConfig.port
+        headers[http2.constants.HTTP2_HEADER_AUTHORITY] = headers.host
+
+        let { hostname, port } = proxyConfig.protocol === 'browser:' || proxyConfig.protocol === 'log:'
+          ? reqUrl
+          : proxyConfig
+        if (port === undefined) {
+          port = proxyConfig.protocol === 'https:' ? 443 : 80
+        }
+
+        const proxyClient = http2.connect(`http://${hostname}:${port}`)
+
+        proxyClient.on('error', async (err) => {
+          const requestBody = await requestBodyPromise
+          httpMessage.emitMessageToBrowser(requestBody, 404, {}, { err, 'anyproxy-config': proxyConfig })
+        })
+
+        const proxyReq = proxyClient.request(headers)
+        clientReq.pipe(proxyReq, {
+          end: true
+        })
+
+        proxyReq.on('response', async (headers, _flags) => {
+          const requestBody = await requestBodyPromise
+          /**
+          * Forward the response back to the client
+          */
+          const headers2 = { ...headers }
+          for (const header in headers2) {
+            if (header.includes(':')) {
+              delete headers2[header]
+            }
+          }
+          clientRes.writeHead(Number(headers[':status']), headers2)
+          proxyReq.pipe(clientRes, {
+            end: true
+          })
+
+          const resBody = await getResBody(proxyReq, headers)
+          httpMessage.emitMessageToBrowser(requestBody, headers[':status'], headers, resBody)
+        })
+
+        proxyReq.on('end', () => {
+          proxyClient.close()
+        })
+      }
+
+      function getReqBody (clientReq: Http2ServerRequest): Promise<string | {}> {
+        return new Promise<string | {}>(resolve => {
+          // eslint-disable-next-line no-unreachable
+          let requestBody: string | {} = ''
+          clientReq.setEncoding('utf8')
+          let rawData = ''
+          clientReq.on('data', function (chunk) {
+            rawData += chunk
+          })
+          // eslint-disable-next-line no-unreachable
+          clientReq.on('end', async function () {
+            try {
+              requestBody = JSON.parse(rawData)
+            } catch (e) {
+              const contentType = clientReq.headers['content-type']
+              if (contentType && contentType.indexOf('application/x-www-form-urlencoded') !== -1) {
+                requestBody = querystring.parse(rawData)
+              } else {
+                requestBody = rawData
+              }
+            }
+            if (proxyConfig.protocol === 'grpc:') {
+              requestBody = HexFormatter.format(Buffer.from(requestBody as string, 'utf-8'))
+            }
+            resolve(requestBody)
+          })
+        })
+      }
+
+      function getResBody (proxyRes: ClientHttp2Stream, headers: http2.IncomingHttpHeaders): Promise<object | string> {
+        return new Promise<string | {}>(resolve => {
+          if (headers['content-encoding']) {
+            proxyRes = decompressResponse(proxyRes)
+          }
+
+          let rawData = ''
+          proxyRes.on('data', function (chunk: string) {
+            rawData += chunk
+          })
+          let parsedData = ''
+          proxyRes.on('end', () => {
+            try {
+              parsedData = JSON.parse(rawData) // assume JSON
+            } catch (e) {
+              parsedData = rawData
+            }
+            if (proxyConfig.protocol === 'grpc:') {
+              parsedData = HexFormatter.format(Buffer.from(parsedData, 'utf-8'))
+            }
+            resolve(parsedData)
+          })
+        })
+      }
+    }
+  }
+
+  static destructor (proxyConfig: ProxyConfig) {
+    if (proxyConfig._server) proxyConfig._server.close()
+  }
+}

--- a/HttpProxy.ts
+++ b/HttpProxy.ts
@@ -182,7 +182,7 @@ export default class HttpProxy {
       proxy.on('error', async function (error) {
         console.error(sequenceNumber, 'Proxy connect error', JSON.stringify(error, null, 2), 'config:', proxyConfig)
         const requestBody = await requestBodyPromise
-        httpMessage.emitMessageToBrowser(requestBody, 404, {}, { error, config: proxyConfig })
+        httpMessage.emitMessageToBrowser(requestBody, 404, {}, { error, 'anyproxy-config': proxyConfig })
       })
 
       clientReq.pipe(proxy, {

--- a/app.ts
+++ b/app.ts
@@ -69,7 +69,7 @@ function usage () {
  */
 process.on('uncaughtException', (err) => {
   console.error(err.stack)
-  process.exit()
+  // process.exit()
 })
 
 Global.socketIoManager = new SocketIoManager()

--- a/client/src/components/Request.tsx
+++ b/client/src/components/Request.tsx
@@ -66,7 +66,7 @@ const Request = observer(({ isActive, onClick, store, onResend, timeBarPercent }
 	)
 
 	function canResend() {
-		return (message.protocol === 'http:' || message.protocol === 'https:')
+		return ((message.protocol === 'http:' || message.protocol === 'https:') && message.proxyConfig?.protocol !== 'grpc:')
 			&& (message.method === 'GET' || message.method === 'POST' || message.method === 'HEAD');
 	}
 })

--- a/client/src/components/Response.tsx
+++ b/client/src/components/Response.tsx
@@ -4,7 +4,6 @@ import { Accordion, AccordionSummary, AccordionDetails, CircularProgress } from 
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ReactJson from 'react-json-view';
 
-
 type Props = {
 	message: Message,
 };

--- a/client/src/store/MessageStore.ts
+++ b/client/src/store/MessageStore.ts
@@ -98,10 +98,12 @@ export default class MessageStore {
                 this.message.requestHeaders['content-type'].includes('application/x-www-form-urlencoded')) {
                 const params = this.message.requestBody.split('&');
                 body += JSON.stringify(params, null, 2);
+            } else if (typeof this.message.requestBody === 'string') {
+                body += this.message.requestBody as string;
             } else {
                 body += JSON.stringify(this.message.requestBody, null, 2);
             }
-            body = Util.fixNewlines(body);
+            // body = Util.fixNewlines(body);
         }
         return body;
     }

--- a/client/src/test/MessageStore.test.ts
+++ b/client/src/test/MessageStore.test.ts
@@ -14,7 +14,7 @@ test("MessageStore", () => {
   const messageStore = new MessageStore(message);
   expect(messageStore.getMessage()).toBe(message);
 
-  expect(messageStore.getRequestBody()).toBe('"requestBody"');
+  expect(messageStore.getRequestBody()).toBe('requestBody');
   expect(messageStore.getUrl()).toBe('/url');
   expect(messageStore.getRequestLine()).toBe('(clientIp->serverHost) /url');
 


### PR DESCRIPTION
The GRCP protocol will now use an HTTP/2 proxy instead of just a TCP proxy.   