### PR TITLE
Handle HTTP2 trailers used by GRPC

### DIFF
--- a/client/src/components/Response.tsx
+++ b/client/src/components/Response.tsx
@@ -27,9 +27,10 @@ const Response = ({ message, store }: Props) => {
 						<div className={store.getGrpcStatus() === 0 ? '' : 'error'}>
 							<b>GRPC Status:&nbsp;</b>{store.getGrpcStatus()}
 						</div>
+						{store.getGrpcMessage().length > 0 && (
 						<div>
 							<b>GRPC Message:&nbsp;</b>{store.getGrpcMessage()}
-						</div>
+						</div>)}
 					</div>
 				)}
 				<div>

--- a/server/src/SocketIoManager.ts
+++ b/server/src/SocketIoManager.ts
@@ -11,7 +11,7 @@ import Ping from './Ping'
 import resend from './Resend'
 import Http2Proxy from '../../Http2Proxy'
 
-const USE_HTTP2 = false
+const USE_HTTP2 = true
 const CONFIG_JSON = process.env.NODE_ENV === 'production'
   ? `${__dirname + '' + path.sep}..${path.sep}..${path.sep}..${path.sep}config.json`
   : `${__dirname + '' + path.sep}.${path.sep}config.json`


### PR DESCRIPTION
This PR re-enables HTTP/2 for gRPC, and handles trailers used by gRPC.