### PR TITLE
V3 10 6: Breakpoint - Implement Undo instead for Cancel button

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -789,20 +789,6 @@ td input {
 	max-width: 400px;
 }
 
-.no-capture-modal__add-button {
-	margin-top: .5rem;
-	font-size: large;
-	cursor: pointer;
-	color: #28a745;
-}
-
-.no-capture-modal__remove {
-	font-size: large;
-	color: red;
-	cursor: pointer;
-	margin-right: .5rem;
-}
-
 .reachable-modal {
 	max-width: 700px;
 }
@@ -845,15 +831,6 @@ td input {
 
 .settings-modal__proxy-protocol-container {
 	white-space: nowrap;
-}
-
-.settings-modal__add-container {
-	padding-left: .5rem;
-	width: 25% !important;
-}
-
-.settings-modal__add-input {
-	width: 100% !important;
 }
 
 .settings-modal__select-protocol {

--- a/client/src/components/BreakpointModal.tsx
+++ b/client/src/components/BreakpointModal.tsx
@@ -1,8 +1,9 @@
-import { List, ListItem, Modal } from '@material-ui/core'
+import { IconButton, List, ListItem, Modal } from '@material-ui/core'
 import BreakpointStore from '../store/BreakpointStore';
 import { observer } from 'mobx-react-lite';
 import { useEffect } from 'react';
 import FilterStore from '../store/FilterStore';
+import CloseIcon from "@material-ui/icons/Close";
 
 type Props = {
 	open: boolean,
@@ -82,20 +83,21 @@ const BreakpointModal = observer(({ open, onClose, store }: Props) => {
 									Only responses with Content-Type application/json are examined.
 								</li>
 							</ul>
-							<div className="no-capture-modal__add-button fa fa-plus-circle"
-								onClick={handleAddBreakpoint}>
-								&nbsp;Add breakpoint
-							</div>
+							<button className="btn btn-lg btn-primary"
+								onClick={handleAddBreakpoint}
+							>
+								+ New Breakpoint
+							</button>
 							<List>
 								{store.getBreakpointList().map((breakpoint, i) => (
 									<ListItem key={i}
 										style={{
 											display: 'flex', alignItems: 'center',
 										}}>
-										<div className="no-capture-modal__remove fa fa-minus-circle"
-											title="Remove breakpoint"
-											onClick={() => handleDeleteBreakpoint(i)} />
-										<button className={`btn ${breakpoint.isEnabled() ? 'btn-primary' : 'btn-secondary'}`}
+										<IconButton onClick={() => handleDeleteBreakpoint(i)} title="Delete breakpoint">
+											<CloseIcon style={{ color: 'red' }} />
+										</IconButton>
+										<button className={`btn ${breakpoint.isEnabled() ? 'btn-success' : 'btn-secondary'}`}
 											onClick={() => handleToggleEnable(breakpoint)}
 											title={breakpoint.isEnabled() ? 'Disable breakpoint' : 'Enable breakpoint'}
 										>

--- a/client/src/components/BreakpointResponseModal.tsx
+++ b/client/src/components/BreakpointResponseModal.tsx
@@ -3,6 +3,7 @@ import { Modal } from '@material-ui/core'
 import MessageStore from '../store/MessageStore';
 import ReactJson, { InteractionProps } from 'react-json-view';
 import { colorScheme } from '../App';
+import React from 'react';
 
 type Props = {
 	open: boolean,
@@ -10,6 +11,8 @@ type Props = {
 	store: MessageStore,
 };
 const BreakpointResponseModal = observer(({ open, onClose, store }: Props) => {
+	const [responseBody, setResponseBody] = React.useState(store.getMessage().responseBody);
+	const [modified, setModified] = React.useState(false);
 	const message = store.getMessage();
 	const saveResponseBody = JSON.parse(JSON.stringify(message.responseBody));
 	return (
@@ -38,7 +41,7 @@ const BreakpointResponseModal = observer(({ open, onClose, store }: Props) => {
 								<button type="button" className="resend-modal__send btn btn-sm btn-primary"
 									style={{ marginLeft: '.5rem' }}
 									onClick={handleToggleStrJson}>
-									{typeof message.responseBody === 'object' ? 'To String' : 'To JSON'}
+									{typeof responseBody === 'object' ? 'To String' : 'To JSON'}
 								</button>
 								<button type="button" className="resend-modal__send btn btn-sm btn-danger"
 									style={{ marginLeft: '.5rem' }}
@@ -47,10 +50,10 @@ const BreakpointResponseModal = observer(({ open, onClose, store }: Props) => {
 								</button>
 							</div>
 							<div className="resend-modal__body-container">
-								{message.responseBody && typeof message.responseBody === 'object' ?
+								{responseBody && typeof responseBody === 'object' ?
 									<ReactJson
-										theme={colorScheme ==='dark' ? 'google' : undefined}
-										src={message.responseBody}
+										theme={colorScheme === 'dark' ? 'google' : undefined}
+										src={responseBody}
 										name={false}
 										displayDataTypes={false}
 										quotesOnKeys={false}
@@ -60,21 +63,25 @@ const BreakpointResponseModal = observer(({ open, onClose, store }: Props) => {
 									/>
 									:
 									<textarea className="resend-modal__body form-control" rows={100} cols={300}
-										onChange={(e) => message.responseBody = e.target.value}
-										value={message.responseBody as string}
+										onChange={(e) => {
+											setResponseBody(e.target.value);
+											setModified(true);
+										}}
+										value={responseBody as string}
 										placeholder="Enter response body" />
 								}
 							</div>
 						</div>
 					</div>
 					<div className="modal-footer">
-						<button type="button" className="settings-modal__cancel btn btn-default btn-secondary"
-							onClick={handleCancel}
+						<button type="button" className="settings-modal__cancel btn btn-default btn-danger"
+							disabled={!modified}
+							onClick={handleUndo}
 						>
-							Cancel
+							Undo
 						</button>
 						<button type="button" className="resend-modal__send btn btn-success"
-							onClick={onClose}
+							onClick={handleOk}
 						>
 							Ok
 						</button>
@@ -85,39 +92,48 @@ const BreakpointResponseModal = observer(({ open, onClose, store }: Props) => {
 	);
 
 	function handleCopy() {
-		const s = typeof message.responseBody === 'object' ? JSON.stringify(message.responseBody, null, 2) : message.responseBody;
+		const s = typeof responseBody === 'object' ? JSON.stringify(responseBody, null, 2) : responseBody;
 		navigator.clipboard.writeText(s);
 	}
 
-	function handleCancel() {
-		message.responseBody = saveResponseBody;
+	function handleOk() {
+		message.responseBody = responseBody;
 		onClose();
 	}
 
+	function handleUndo() {
+		setResponseBody(saveResponseBody);
+		setModified(false);
+	}
+
 	function handleToggleStrJson() {
-		if (typeof message.responseBody === 'object') {
-			message.responseBody = JSON.stringify(message.responseBody, null, 2);
+		if (typeof responseBody === 'object') {
+			setResponseBody(JSON.stringify(responseBody, null, 2));
 		} else {
-			message.responseBody = JSON.parse(message.responseBody as string);
+			setResponseBody(JSON.parse(responseBody as string));
 		}
 	}
 
 	function handleClear() {
-		message.responseBody = '';
+		setModified(true);
+		setResponseBody('');
 	}
 
 	function handleEdit(props: InteractionProps) {
-		message.responseBody = props.updated_src;
+		setModified(true);
+		setResponseBody(props.updated_src);
 		return true;
 	}
 
 	function handleAdd(props: InteractionProps) {
-		message.responseBody = props.updated_src;
+		setModified(true);
+		setResponseBody(props.updated_src);
 		return true;
 	}
 
 	function handleDelete(props: InteractionProps) {
-		message.responseBody = props.updated_src;
+		setModified(true);
+		setResponseBody(props.updated_src);
 		return true;
 	}
 })

--- a/client/src/components/NoCaptureModal.tsx
+++ b/client/src/components/NoCaptureModal.tsx
@@ -1,7 +1,8 @@
-import { List, ListItem, Modal } from '@material-ui/core'
+import { IconButton, List, ListItem, Modal } from '@material-ui/core'
 import NoCaptureStore from '../store/NoCaptureStore';
 import { observer } from 'mobx-react-lite';
 import { useState } from 'react';
+import CloseIcon from "@material-ui/icons/Close";
 
 type Props = {
 	open: boolean,
@@ -42,7 +43,7 @@ const NoCaptureModal = observer(({ open, onClose, store }: Props) => {
 			open={open}
 			onClose={close}
 			aria-labelledby="simple-modal-title"
-  		aria-describedby="simple-modal-description"
+			aria-describedby="simple-modal-description"
 		>
 			<div className="no-capture-modal" role="dialog">
 				<div>
@@ -51,17 +52,19 @@ const NoCaptureModal = observer(({ open, onClose, store }: Props) => {
 						<div className="no-capture-modal__scroll-container">
 							<div><strong>Do not capture messages from these clients.</strong></div>
 							<div>(The list is stored in browser local storage.)</div>
-							<div className="no-capture-modal__add-button fa fa-plus-circle"
-								onClick={handleAddClient}>
-								&nbsp;Add client
-							</div>
+							<button className="btn btn-lg btn-primary"
+								style={{ marginTop: '1rem' }}
+								onClick={handleAddClient}
+							>
+								+ New Client
+							</button>
 							<List>
 								{store.getClientList().map((clientHost, i) => (
 									<ListItem key={i}
-										style={{display: 'flex', alignItems: 'center'}}>
-										<div className="no-capture-modal__remove fa fa-minus-circle"
-											title="Remove client"
-											onClick={() => handleDeleteClient(i)}/>
+										style={{ display: 'flex', alignItems: 'center' }}>
+										<IconButton onClick={() => handleDeleteClient(i)} title="Remove client">
+											<CloseIcon style={{ color: 'red' }} />
+										</IconButton>
 										<input className="form-control"
 											placeholder="Client host or IP (regex allowed)"
 											value={clientHost}
@@ -74,20 +77,20 @@ const NoCaptureModal = observer(({ open, onClose, store }: Props) => {
 					</div>
 					<div className="modal-footer">
 						<button type="button" className="settings-modal__cancel btn btn-secondary"
-							onClick={ close }
+							onClick={close}
 						>
 							Cancel
 						</button>
 						<button type="button" className="settings-modal__cancel btn btn-success"
 							disabled={saveDisabled}
-							onClick={ onSave }
+							onClick={onSave}
 						>
 							Save
 						</button>
 					</div>
 				</div>
 			</div>
-		</Modal>
+		</Modal >
 	);
 });
 

--- a/client/src/components/SettingsModal.tsx
+++ b/client/src/components/SettingsModal.tsx
@@ -122,63 +122,11 @@ const SettingsModal = observer(({ open, onClose, store }: Props) => {
 						))}
 					</TabContext>
 					<div style={{ borderTop: 'solid steelblue', paddingTop: '.5rem' }}>
-						<button className="settings-modal__add-button btn btn-lg btn-primary"
+						<button className="btn btn-lg btn-primary"
 							onClick={() => store.addEntry()}
 						>
 							+ New Rule
 						</button>
-						<table className="table" hidden>
-							<tbody>
-								<tr >
-									<td className="settings-modal__add-container">
-										<input type="text" className="form-control settings-modal__add-input"
-											placeholder={
-												store.getProtocol() === 'log:'
-													? 'Log tail command (e.g., docker logs -f container)'
-													: store.getProtocol() === 'http:'
-														|| store.getProtocol() === 'https:'
-														? 'Path: /xxx, .*/xxx, or hostname/xxx'
-														: store.getProtocol() === 'browser:'
-															? 'Path: /xxx, or .*/xxx'
-															: 'Source TCP port'
-											}
-											value={store.getPath()}
-											onChange={(e) => store.setPath(e.target.value)}
-										/>
-									</td>
-									<td className="settings-modal__add-container">
-										<input type="text" className="form-control settings-modal__add-input"
-											hidden={store.isProxyOrLog()}
-											placeholder={store.isProxyOrLog() ? '' : 'Target host name'}
-											value={store.getTargetHost()}
-											onChange={(e) => store.setTargetHost(e.target.value)}
-										/>
-									</td>
-									<td className="settings-modal__add-container">
-										<input type="text" className="form-control settings-modal__add-input"
-											hidden={store.isProxyOrLog()}
-											placeholder={store.isProxyOrLog() ? '' : 'Target port number'}
-											value={store.getTargetPort()}
-											onChange={(e) => store.setTargetPort(e.target.value)}
-										/>
-									</td>
-									<td className="settings-modal__add-container">
-										<input type="text" className="form-control settings-modal__add-input"
-											placeholder={'Optional comment'}
-											value={store.getComment()}
-											onChange={(e) => store.setComment(e.target.value)}
-										/>
-									</td>
-									<td className="settings-modal__add-button-container">
-										<button className="settings-modal__add-button btn btn-primary"
-											onClick={() => store.addEntry()}
-										>
-											Add
-										</button>
-									</td>
-								</tr>
-							</tbody>
-						</table>
 						<table>
 							<tbody>
 								<tr>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "allproxy",
-  "version": "3.10.5",
+  "version": "3.10.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "allproxy",
-      "version": "3.10.5",
+      "version": "3.10.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "allproxy",
-  "version": "3.10.5",
+  "version": "3.10.6",
   "description": "AllProxy: MITM HTTP Debugging Tool.",
   "keywords": [
     "proxy",


### PR DESCRIPTION
* style changes for breakpoint config modal and no capture client modals
* The breakpoint modal Cancel button was changed to an Undo button, to allow changes to be undone, if needed.   The Ok button is used to forward the modified or unmodified response back to the client.