### PR TITLE
V3 25 5: Detect ostype in browser and send to docker container

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -105,27 +105,7 @@ process.on('exit', () => BrowserLauncher.shutdown());
 Paths.makeCaPemSymLink();
 Paths.setupInterceptDir();
 
-const dirName = __dirname + path.sep + '..';
-const dataDir = process.env.ALLPROXY_DATA_DIR;
-if (dataDir) {
-  const binPath = ':/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin';
-  switch (process.platform) {
-    case 'darwin':
-      fs.copyFileSync(`${dirName + path.sep}/bin/macos/trustCert.sh`, `${dataDir}/bin/trustCert.sh`);
-      fs.copyFileSync(`${dirName + path.sep}/bin/macos/systemProxy.sh`, `${dataDir}/bin/systemProxy.sh`);
-      process.env.PATH += binPath;
-      break;
-    case 'win32':
-      fs.copyFileSync(`${dirName + path.sep}bin\\windows\\trustCert.bat`, `${dataDir}\\bin\\trustCert.bat`);
-      fs.copyFileSync(`${dirName + path.sep}bin\\windows\\systemProxy.bat`, `${dataDir}\\bin\\systemProxy.bat`);
-      break;
-    case 'linux':
-      fs.copyFileSync(`${dirName + path.sep}/bin/linux/trustCert.sh`, `${dataDir}/bin/trustCert.sh`);
-      fs.copyFileSync(`${dirName + path.sep}/bin/linux/systemProxy.sh`, `${dataDir}/bin/systemProxy.sh`);
-      process.env.PATH += binPath;
-      break;
-  }
-}
+setOsBinaries(process.platform)
 
 Global.portConfig = new PortConfig();
 Global.socketIoManager = new SocketIoManager();
@@ -162,6 +142,30 @@ async function startServers() {
         GrpcProxy.forwardProxy(port, true);
         console.log(`Listening on secure gRPC ${host || ''} ${port}`);
         Global.portConfig.grpcSecurePort = port;
+        break;
+    }
+  }
+}
+
+export function setOsBinaries(os: string) {
+  const dirName = __dirname + path.sep + '..';
+  const dataDir = process.env.ALLPROXY_DATA_DIR;
+  if (dataDir) {
+    const binPath = ':/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin';
+    switch (os) {
+      case 'darwin':
+        fs.copyFileSync(`${dirName + path.sep}/bin/macos/trustCert.sh`, `${dataDir}/bin/trustCert.sh`);
+        fs.copyFileSync(`${dirName + path.sep}/bin/macos/systemProxy.sh`, `${dataDir}/bin/systemProxy.sh`);
+        process.env.PATH += binPath;
+        break;
+      case 'win32':
+        fs.copyFileSync(`${dirName + path.sep}bin\\windows\\trustCert.bat`, `${dataDir}\\bin\\trustCert.bat`);
+        fs.copyFileSync(`${dirName + path.sep}bin\\windows\\systemProxy.bat`, `${dataDir}\\bin\\systemProxy.bat`);
+        break;
+      case 'linux':
+        fs.copyFileSync(`${dirName + path.sep}/bin/linux/trustCert.sh`, `${dataDir}/bin/trustCert.sh`);
+        fs.copyFileSync(`${dirName + path.sep}/bin/linux/systemProxy.sh`, `${dataDir}/bin/systemProxy.sh`);
+        process.env.PATH += binPath;
         break;
     }
   }

--- a/client/src/store/SocketStore.ts
+++ b/client/src/store/SocketStore.ts
@@ -36,6 +36,15 @@ export default class SocketStore {
 			this.setSocketConnected(true);
 			if (this.socket) {
 				apFileSystem.setSocket(this.socket);
+
+				var os = '';
+				if (navigator.userAgent.indexOf('Win') !== -1) os = 'win32';
+				else if (navigator.userAgent.indexOf('Mac') !== -1) os = 'darwin';
+				else if (navigator.userAgent.indexOf('Linux') !== -1) os = 'linux';
+
+				if (os.length > 0) {
+					this.socket.emit('ostype', os);
+				}
 			}
 		});
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "allproxy",
-  "version": "3.23.4",
+  "version": "3.23.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "allproxy",
-      "version": "3.23.4",
+      "version": "3.23.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "allproxy",
-  "version": "3.23.4",
+  "version": "3.23.5",
   "description": "AllProxy: MITM HTTP Debugging Tool.",
   "keywords": [
     "proxy",

--- a/server/src/SocketIoManager.ts
+++ b/server/src/SocketIoManager.ts
@@ -15,6 +15,7 @@ import ConsoleLog from './ConsoleLog';
 import BrowserLauncher from './BrowserLauncher';
 import Launcher from '@httptoolkit/browser-launcher';
 import APFileSystem from './APFileSystem';
+import { setOsBinaries } from '../../app';
 
 const USE_HTTP2 = true;
 const CONFIG_JSON = Paths.configJson();
@@ -151,6 +152,10 @@ export default class SocketIoManager {
     socket.emit('port config', Global.portConfig); // send port config to browser
 
     socket.emit('proxy config', config); // send config to browser
+
+    socket.on('ostype', (os: string) => {
+      setOsBinaries(os);
+    })
 
     socket.on('proxy config', (proxyConfigs: ProxyConfig[]) => {
       ConsoleLog.info(`${Paths.configJson()}:\n`, proxyConfigs);


### PR DESCRIPTION
The browser ostype enables the docker container to correctly set the OS specific brinaries